### PR TITLE
Adds a check for strict types

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,10 @@ parametersSchema:
 
 services:
     -
+        class: Worksome\CodingStyle\PHPStan\DeclareStrictTypesRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Worksome\CodingStyle\PHPStan\NamespaceBasedSuffixRule
         arguments:
             namespaceAndSuffix: %namespaceAndSuffix%

--- a/src/PHPStan/DeclareStrictTypesRule.php
+++ b/src/PHPStan/DeclareStrictTypesRule.php
@@ -24,11 +24,11 @@ class DeclareStrictTypesRule implements Rule
     {
         $nodes = $node->getNodes();
 
-        if (0 === \count($nodes)) {
+        if (count($nodes) === 0) {
             return [];
         }
 
-        $firstNode = \array_shift($nodes);
+        $firstNode = array_shift($nodes);
 
         if ($firstNode instanceof Node\Stmt\Declare_) {
             foreach ($firstNode->declares as $declare) {

--- a/src/PHPStan/DeclareStrictTypesRule.php
+++ b/src/PHPStan/DeclareStrictTypesRule.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Worksome\CodingStyle\PHPStan;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<FileNode>
+ */
+class DeclareStrictTypesRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return FileNode::class;
+    }
+
+    /**
+     * @param FileNode $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $nodes = $node->getNodes();
+
+        if (0 === \count($nodes)) {
+            return [];
+        }
+
+        $firstNode = \array_shift($nodes);
+
+        if ($firstNode instanceof Node\Stmt\Declare_) {
+            foreach ($firstNode->declares as $declare) {
+                if (
+                    'strict_types' === $declare->key->toLowerString()
+                    && $declare->value instanceof Node\Scalar\LNumber
+                    && 1 === $declare->value->value
+                ) {
+                    return [];
+                }
+            }
+        }
+
+        return [
+            'PHP files should declare strict types.',
+        ];
+    }
+}

--- a/tests/PHPStan/DeclareStrictTypesRule/DelcareStrictTypesRuleTest.php
+++ b/tests/PHPStan/DeclareStrictTypesRule/DelcareStrictTypesRuleTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Worksome\CodingStyle\Tests\PHPStan\DeclareStrictTypesRule;
+
+use Worksome\CodingStyle\PHPStan\DeclareStrictTypesRule;
+
+it('checks for declaration of strict types', function (string $path, array ...$errors) {
+    $this->rule = new DeclareStrictTypesRule();
+
+    expect($path)->toHaveRuleErrors($errors);
+})->with([
+    'missing strict types' => [
+        __DIR__ . '/Fixture/fixture.php.excluding',
+        [
+            'PHP files should declare strict types.',
+            3,
+        ],
+    ],
+    'file with strict types' => [
+        __DIR__ . '/Fixture/fixture.php.including',
+    ],
+]);

--- a/tests/PHPStan/DeclareStrictTypesRule/Fixture/fixture.php.excluding
+++ b/tests/PHPStan/DeclareStrictTypesRule/Fixture/fixture.php.excluding
@@ -1,0 +1,5 @@
+<?php
+
+class BalanceUpdated
+{
+}

--- a/tests/PHPStan/DeclareStrictTypesRule/Fixture/fixture.php.including
+++ b/tests/PHPStan/DeclareStrictTypesRule/Fixture/fixture.php.including
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+class BalanceUpdated
+{
+}


### PR DESCRIPTION
This adds a requirement for files to declare strict types. I opted to do this through PHPStan rather than a sniff so that we can easily generate a baseline for existing files.