### PR TITLE
Adds `resolve` to forbidden function all along with `app`

### DIFF
--- a/src/PHPStan/Laravel/DisallowAppHelperUsageRule.php
+++ b/src/PHPStan/Laravel/DisallowAppHelperUsageRule.php
@@ -13,7 +13,10 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class DisallowAppHelperUsageRule implements Rule
 {
-    const FUNCTION_NAME = 'app';
+    private array $forbiddenFunctions = [
+        'app',
+        'resolve',
+    ];
 
     public function getNodeType(): string
     {
@@ -33,13 +36,13 @@ class DisallowAppHelperUsageRule implements Rule
 
         $functionName = $nodeName->toString();
 
-        if ($functionName !== self::FUNCTION_NAME) {
+        if (! in_array($functionName, $this->forbiddenFunctions)) {
             return [];
         }
 
         return [
             RuleErrorBuilder::message(
-                "Usage of app helper is disallowed. Use dependency injection instead."
+                "Usage of {$functionName} helper is disallowed. Use dependency injection instead."
             )->build(),
         ];
     }

--- a/tests/PHPStan/Laravel/DisallowAppUsageRule/DisallowAppUsageRuleTest.php
+++ b/tests/PHPStan/Laravel/DisallowAppUsageRule/DisallowAppUsageRuleTest.php
@@ -16,6 +16,13 @@ it('checks app helper rule', function (string $path, array ...$errors) {
             7,
         ],
     ],
+    'calls resolve helper with parameters' => [
+        __DIR__ . '/Fixture/resolve_helper_with_parameters.php.inc',
+        [
+            'Usage of resolve helper is disallowed. Use dependency injection instead.',
+            7,
+        ],
+    ],
     'calls app helper without args' => [
         __DIR__ . '/Fixture/app_helper_without_arg.php.inc',
         [
@@ -25,6 +32,9 @@ it('checks app helper rule', function (string $path, array ...$errors) {
     ],
     'skips app function from other namespace' => [
         __DIR__ . '/Fixture/skip_app_function_in_namespace.php.inc',
+    ],
+    'skips resolve function from other namespace' => [
+        __DIR__ . '/Fixture/skip_resolve_function_in_namespace.php.inc',
     ],
     'skips function call on variable' => [
         __DIR__ . '/Fixture/skip_variable_call.php.inc',
@@ -36,10 +46,24 @@ it('checks app helper rule', function (string $path, array ...$errors) {
             9,
         ],
     ],
+    'calls resolve helper when inside a namespace' => [
+        __DIR__ . '/Fixture/resolve_helper_in_namespace.php.inc',
+        [
+            'Usage of resolve helper is disallowed. Use dependency injection instead.',
+            9,
+        ],
+    ],
     'calls app helper with chain calls after' => [
         __DIR__ . '/Fixture/app_helper_with_chain_calls.php.inc',
         [
             'Usage of app helper is disallowed. Use dependency injection instead.',
+            9,
+        ],
+    ],
+    'calls resolve helper with chain calls after' => [
+        __DIR__ . '/Fixture/resolve_helper_with_chain_calls.php.inc',
+        [
+            'Usage of resolve helper is disallowed. Use dependency injection instead.',
             9,
         ],
     ],

--- a/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/resolve_helper_in_namespace.php.inc
+++ b/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/resolve_helper_in_namespace.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Resolve\Services;
+
+class CallsResolveHelper
+{
+    public function method()
+    {
+        return resolve('myService');
+    }
+}
+
+?>

--- a/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/resolve_helper_with_chain_calls.php.inc
+++ b/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/resolve_helper_with_chain_calls.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Resolve\Services;
+
+class CallsResolveHelper
+{
+    public function method()
+    {
+        return \resolve('myService')->execute();
+    }
+}
+
+?>

--- a/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/resolve_helper_with_parameters.php.inc
+++ b/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/resolve_helper_with_parameters.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+class CallsResolveHelper
+{
+    public function method()
+    {
+        return \resolve('myService', ['foo' => 'bar']);
+    }
+}
+
+?>

--- a/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/skip_resolve_function_in_namespace.php.inc
+++ b/tests/PHPStan/Laravel/DisallowAppUsageRule/Fixture/skip_resolve_function_in_namespace.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+class CallsOtherResolveHelper
+{
+    public function container()
+    {
+        return \MyCustom\resolve();
+    }
+}
+
+?>


### PR DESCRIPTION
Currently, the `DisallowAppHelperUsageRule` only prevents usage of `app()`. However, you can bypass this by using the `resolve()` function, which basically does the same thing. 

The rule has now been updated to also forbid usage of `resolve()`.