### PR TITLE
feature: JIRA-5937 Added PHP-CS rules for import ordering

### DIFF
--- a/src/PhpCsFixerConfig.php
+++ b/src/PhpCsFixerConfig.php
@@ -13,6 +13,14 @@ class PhpCsFixerConfig extends Config
                 'align' => 'vertical',
             ],
             'phpdoc_separation' => true,
+            'ordered_imports' => [
+                'imports_order' => [
+                    'class',
+                    'function',
+                    'const',
+                ],
+                'sort_algorithm' => 'alpha',
+            ],
         ],
         '@worksome:risky' => [
             // ...


### PR DESCRIPTION
The new PHP-CS-Fixer rules will order `use` statements alphabetically.