### PR TITLE
Prevents various global functions in Laravel.

### DIFF
--- a/larastan.neon
+++ b/larastan.neon
@@ -34,21 +34,44 @@ services:
         class: Vural\LarastanStrictRules\Rules\NoPropertyAccessorRule
         tags:
             - phpstan.rules.rule
-#    -
-#        class: Vural\LarastanStrictRules\Rules\NoGlobalLaravelFunctionRule
-#        arguments:
-#            allowedFunctions:
-#                - collect
-#                - data_get
-#                - now
-#                - optional
-#                - tap
-#                - throw_if
-#                - throw_unless
-#                - value
-#                - with
-#        tags:
-#            - phpstan.rules.rule
+    -
+        class: Vural\LarastanStrictRules\Rules\NoGlobalLaravelFunctionRule
+        arguments:
+            allowedFunctions:
+                - class_basename
+                - class_uses_recursive
+                - e
+                - env
+                - object_get
+                - preg_replace_array
+                - retry
+                - str
+                - tap
+                - throw_if
+                - throw_unless
+                - trait_uses_recursive
+                - with
+                - collect
+                - data_fill
+                - data_get
+                - data_set
+                - value
+                - config
+                - csrf_field
+                - csrf_token
+                - fake
+                - method_field
+                - now
+                - old
+                - redirect
+                - response
+                - route
+                - trans
+                - trans_choice
+                - __
+                - view
+        tags:
+            - phpstan.rules.rule
 #    -
 #        class: Vural\LarastanStrictRules\Rules\NoLocalQueryScopeRule
 #        tags:

--- a/larastan.neon
+++ b/larastan.neon
@@ -57,8 +57,6 @@ services:
                 - data_set
                 - value
                 - config
-                - csrf_field
-                - csrf_token
                 - fake
                 - method_field
                 - now
@@ -70,6 +68,7 @@ services:
                 - trans_choice
                 - __
                 - view
+                - url
         tags:
             - phpstan.rules.rule
 #    -

--- a/larastan.neon
+++ b/larastan.neon
@@ -69,6 +69,9 @@ services:
                 - __
                 - view
                 - url
+                - secure_url
+                - asset
+                - secure_asset
         tags:
             - phpstan.rules.rule
 #    -


### PR DESCRIPTION
This PR aims to prevent the use of certain global helper functions in Laravel. We do not prevent all global helpers. Here is a list of allowed helpers:

| Abbreviation | Meaning |
| ---- | ---- |
| BF | Basic Function. Does not access the container. |
| UOD | Usefulness Outweighs Downsides. The pros of using the function, when taking into account where it is used, outweigh any cons. |

- class_basename (BF)
- class_uses_recursive (BF)
- e (BF)
- env (UOD)
- object_get (BF)
- preg_replace_array (BF)
- retry (BF)
- str (BF)
- tap (BF)
- throw_if (BF)
- throw_unless (BF)
- trait_uses_recursive (BF)
- with (BF)
- collect (BF)
- data_fill (BF)
- data_get (BF)
- data_set (BF)
- value (BF)
- config (UOD)
- fake (only used in tests)
- now (BF - Date facade is resolved without need of container)
- old (UOD)
- redirect (only used in Controllers)
- response (only used in Controllers)
- route (UOD)
- trans (UOD)
- trans_choice (UOD)
- __ (UOD)
- view (only used in Controllers)

A couple of thoughts for the reviewer: Should we remove allowing the use of `__()` to enforce using only `trans()`? Also, are there any other functions you believe should be allowed in the platform?

For a list of functions, see the following files:

- `vendor/illuminate/collections/helpers.php`
- `vendor/illuminate/support/helpers.php`
- `vendor/laravel/framework/src/Illuminate/Foundation/helpers.php`