### PR TITLE
chore: Bump Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "nunomaduro/larastan": "^1.0 || ^2.0",
         "phpstan/phpstan": "^1.6",
         "phpstan/phpstan-mockery": "^1.0",
-        "rector/rector": "^0.13",
+        "rector/rector": "^0.14",
         "worksome/code-sniffer": "^0.10"
     },
     "require-dev": {


### PR DESCRIPTION
This bumps Rector to latest dep. Apparently Composer can't handle `^0.13` and `0.14` (on Platform) very well 😅 

Hopefully this allows the bump on Platform 🤞 