### PR TITLE
feat: add rule to disallow facades

### DIFF
--- a/larastan.neon
+++ b/larastan.neon
@@ -23,6 +23,10 @@ services:
         tags:
             - phpstan.rules.rule
     -
+        class: Vural\LarastanStrictRules\Rules\NoFacadeRule
+        tags:
+            - phpstan.rules.rule
+    -
         class: Vural\LarastanStrictRules\Rules\NoValidationInControllerRule
         tags:
             - phpstan.rules.rule


### PR DESCRIPTION
This disallows facades in our codebase. We'll probably need to add the following to our app configurations:

```neon
parameters:
  ignoreErrors:
    - message: '#[a-zA-Z0-9\\_]+ facade should not be used.#'
      paths:
        - tests
        - routes
```