### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,4 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Test php code
-        run: vendor/bin/pest --testsuite ${{ matrix.test-suite }}
+        run: vendor/bin/pest -p --testsuite ${{ matrix.test-suite }}

--- a/composer.json
+++ b/composer.json
@@ -5,24 +5,24 @@
     "require": {
         "php": "^8.2",
         "composer-plugin-api": "^2.0",
-        "canvural/larastan-strict-rules": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.8",
+        "canvural/larastan-strict-rules": "^2.1.8",
+        "friendsofphp/php-cs-fixer": "^3.22",
         "jetbrains/phpstorm-attributes": "^1.0",
-        "nunomaduro/larastan": "^2.3.4",
-        "phpstan/phpstan": "^1.6",
-        "phpstan/phpstan-mockery": "^1.0",
+        "nunomaduro/larastan": "^2.6.4",
+        "phpstan/phpstan": "^1.10.28",
+        "phpstan/phpstan-mockery": "^1.1.1",
         "rector/rector": "^0.16",
-        "slevomat/coding-standard": "^8.5",
-        "spaze/phpstan-disallowed-calls": "^2.8",
-        "squizlabs/php_codesniffer": "^3.6.1",
-        "symplify/easy-coding-standard": "^11.1",
-        "thecodingmachine/safe": "^2.0"
+        "slevomat/coding-standard": "^8.13.4",
+        "spaze/phpstan-disallowed-calls": "^2.16",
+        "squizlabs/php_codesniffer": "^3.7.2",
+        "symplify/easy-coding-standard": "^11.5",
+        "thecodingmachine/safe": "^2.5"
     },
     "require-dev": {
         "composer/composer": "^2.5",
-        "pestphp/pest": "^2.0",
-        "spatie/invade": "^1.0",
-        "spatie/ray": "^1.32"
+        "pestphp/pest": "^2.13",
+        "spatie/invade": "^1.1.1",
+        "spatie/ray": "^1.37.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "nunomaduro/larastan": "^2.6.4",
         "phpstan/phpstan": "^1.10.38",
         "phpstan/phpstan-mockery": "^1.1.1",
-        "rector/rector": "^0.16",
+        "rector/rector": "^0.18.5",
         "slevomat/coding-standard": "^8.14.1",
         "spaze/phpstan-disallowed-calls": "^2.16",
         "squizlabs/php_codesniffer": "^3.7.2",

--- a/composer.json
+++ b/composer.json
@@ -6,23 +6,23 @@
         "php": "^8.2",
         "composer-plugin-api": "^2.0",
         "canvural/larastan-strict-rules": "^2.1.8",
-        "friendsofphp/php-cs-fixer": "^3.22",
+        "friendsofphp/php-cs-fixer": "^3.34.1",
         "jetbrains/phpstorm-attributes": "^1.0",
         "nunomaduro/larastan": "^2.6.4",
-        "phpstan/phpstan": "^1.10.28",
+        "phpstan/phpstan": "^1.10.38",
         "phpstan/phpstan-mockery": "^1.1.1",
         "rector/rector": "^0.16",
-        "slevomat/coding-standard": "^8.13.4",
+        "slevomat/coding-standard": "^8.14.1",
         "spaze/phpstan-disallowed-calls": "^2.16",
         "squizlabs/php_codesniffer": "^3.7.2",
         "symplify/easy-coding-standard": "^11.5",
         "thecodingmachine/safe": "^2.5"
     },
     "require-dev": {
-        "composer/composer": "^2.5",
-        "pestphp/pest": "^2.13",
+        "composer/composer": "^2.6.5",
+        "pestphp/pest": "^2.21",
         "spatie/invade": "^1.1.1",
-        "spatie/ray": "^1.37.2"
+        "spatie/ray": "^1.39"
     },
     "autoload": {
         "psr-4": {
@@ -39,6 +39,10 @@
         {
             "name": "Oliver Nybroe",
             "email": "oliver@worksome.com"
+        },
+        {
+            "name": "Owen Voke",
+            "email": "owen.voke@worksome.com"
         }
     ],
     "extra": {

--- a/src/Enums/AttributeKey.php
+++ b/src/Enums/AttributeKey.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\CodingStyle\Enums;
+
+enum AttributeKey: string
+{
+    case Next = 'next';
+    case Parent = 'parent';
+}

--- a/src/PHPStan/Laravel/DisallowPartialRouteResource/DisallowPartialRouteVariableResourceRule.php
+++ b/src/PHPStan/Laravel/DisallowPartialRouteResource/DisallowPartialRouteVariableResourceRule.php
@@ -7,7 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Worksome\CodingStyle\Enums\AttributeKey;
 
 /**
  * @implements Rule<Node\Expr\MethodCall>
@@ -51,14 +51,14 @@ class DisallowPartialRouteVariableResourceRule implements Rule
             return false;
         }
 
-        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parent = $node->getAttribute(AttributeKey::Parent->value);
 
         while ($parent !== null) {
             if ($parent instanceof Node\Expr\StaticCall) {
                 return $parent->class->toString() === Route::class;
             }
 
-            $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+            $parent = $parent->getAttribute(AttributeKey::Parent->value);
         }
 
         return false;

--- a/src/PHPStan/Laravel/DisallowPartialRouteResource/PartialRouteResourceInspector.php
+++ b/src/PHPStan/Laravel/DisallowPartialRouteResource/PartialRouteResourceInspector.php
@@ -5,7 +5,7 @@ namespace Worksome\CodingStyle\PHPStan\Laravel\DisallowPartialRouteResource;
 use PhpParser\Node;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Worksome\CodingStyle\Enums\AttributeKey;
 
 final class PartialRouteResourceInspector
 {
@@ -48,14 +48,14 @@ final class PartialRouteResourceInspector
 
     public function inspect(Node $node): array
     {
-        $next = $node->getAttribute(AttributeKey::NEXT_NODE);
+        $next = $node->getAttribute(AttributeKey::Next->value);
 
         while ($next !== null) {
             if (in_array($next->name, $this->partialMethods)) {
                 return [$this->errorFor($next->name)];
             }
 
-            $next = $next->getAttribute(AttributeKey::PARENT_NODE)->getAttribute(AttributeKey::NEXT_NODE);
+            $next = $next->getAttribute(AttributeKey::Parent->value)->getAttribute(AttributeKey::Next->value);
         }
 
         return [];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,7 +25,7 @@ class Plugin implements PluginInterface, Capable
     public function getCapabilities(): array
     {
         return [
-          CommandProvider::class => CodingStyleCommandProvider::class,
+            CommandProvider::class => CodingStyleCommandProvider::class,
         ];
     }
 }


### PR DESCRIPTION
This updates all dependencies and updates Rector to `^0.18` in preperation for Rector 1.0 👀

I've also updated tests to run in Parallel for speed in CI. 🙌🏻

The `AttributeKey` class has been removed from Rector, so I've created our own enum implementation of this at `Worksome\CodingStyle\Enums\AttributeKey` 👍🏻

The Rector rules have been updated as [part of the update to Rector 0.17](https://getrector.com/blog/rector-017-brings-more-robust-and-lighter-node-tree) / 0.18. The code functions in the same way, just Rector rules no longer support using `removeNode()`. This cleans up the code quite significantly. 🤷🏻