### PR TITLE
chore(deps): update Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,23 +6,23 @@
         "php": "^8.2",
         "composer-plugin-api": "^2.0",
         "canvural/larastan-strict-rules": "^2.1.8",
-        "friendsofphp/php-cs-fixer": "^3.34.1",
         "jetbrains/phpstorm-attributes": "^1.0",
         "nunomaduro/larastan": "^2.6.4",
-        "phpstan/phpstan": "^1.10.38",
+        "phpstan/phpstan": "^1.10.46",
         "phpstan/phpstan-mockery": "^1.1.1",
-        "rector/rector": "^0.18.5",
+        "rector/rector": "^0.18.11",
         "slevomat/coding-standard": "^8.14.1",
         "spaze/phpstan-disallowed-calls": "^2.16",
-        "squizlabs/php_codesniffer": "^3.7.2",
-        "symplify/easy-coding-standard": "^11.5",
+        "symplify/easy-coding-standard": "^12.0.9",
         "thecodingmachine/safe": "^2.5"
     },
     "require-dev": {
         "composer/composer": "^2.6.5",
-        "pestphp/pest": "^2.21",
+        "friendsofphp/php-cs-fixer": "^3.40",
+        "pestphp/pest": "^2.26",
         "spatie/invade": "^1.1.1",
-        "spatie/ray": "^1.39"
+        "spatie/ray": "^1.39",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "php": "^8.2",
         "composer-plugin-api": "^2.0",
-        "canvural/larastan-strict-rules": "^2.1.8",
+        "canvural/larastan-strict-rules": "^2.1.9",
         "jetbrains/phpstorm-attributes": "^1.0",
-        "nunomaduro/larastan": "^2.6.4",
+        "nunomaduro/larastan": "^2.7",
         "phpstan/phpstan": "^1.10.46",
         "phpstan/phpstan-mockery": "^1.1.1",
         "rector/rector": "^0.18.11",

--- a/src/WorksomeRectorConfig.php
+++ b/src/WorksomeRectorConfig.php
@@ -2,12 +2,12 @@
 
 namespace Worksome\CodingStyle;
 
+use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
-use Rector\Php74\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;


### PR DESCRIPTION
This updates to the latest ECS, and Rector versions.

It also moves the PHP-CS-Fixer and PHP_CodeSniffer dependencies to `dev` as they are included by ECS. 👍🏻