### PR TITLE
fix: update `PropertyDoc` to support unions

### DIFF
--- a/src/Sniffs/Support/PropertyDoc.php
+++ b/src/Sniffs/Support/PropertyDoc.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use function Safe\preg_match;
 
-final class PropertyDoc
+final readonly class PropertyDoc
 {
     public function __construct(
         private string $scope,
@@ -75,11 +75,11 @@ final class PropertyDoc
         return <<<REGEXP
         /
         (                                       # Capture group #1.
-            [$\\\\\w-]+                           # Match any word, including words with '$', '\', or '-' symbols.
+            [$\\\\\w&|-]+                       # Match any word, including words with '$', '\', '&', '|', or '-' symbols.
             (                                   # Capture group #2.
-                [\[{<]                            # Match any '<' or '{' symbols, which are used in PHPStan generics.
-                (?:[^\[\]{}<>]+|(?2))*+             # Recursively ignore any matching sets of '<' and '>', '{' and '}' or '[' and ']' found in nested types. Eg: `Collection<int, array<string, string>>`.
-                [\]}>]                            # Until we match the closing '>' or '}'.
+                [\[{<]                          # Match any '<' or '{' symbols, which are used in PHPStan generics.
+                (?:[^\[\]{}<>]+|(?2))*+         # Recursively ignore any matching sets of '<' and '>', '{' and '}' or '[' and ']' found in nested types. Eg: `Collection<int, array<string, string>>`.
+                [\]}>]                          # Until we match the closing '>' or '}'.
             )?                                  # End capture group #2. Not all types are generics, so capture group 2 is optional.
         )                                       # End capture group #1.
         (                                       # Capture group #3.

--- a/testResources/Sniffs/PhpDoc/PropertyDollarSignSniff/Fixed/InvalidProperties.php.fixed
+++ b/testResources/Sniffs/PhpDoc/PropertyDollarSignSniff/Fixed/InvalidProperties.php.fixed
@@ -12,6 +12,8 @@ namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\PhpDoc\PropertyDollarSig
  * @property string[] $whoops
  * @property positive-int $nice_int
  * @property non-empty-array<\Exception> $non_empty_array
+ * @property ABC|EFG $union_type
+ * @property ABC&EFG $intersection_type
  */
 class InvalidProperties
 {

--- a/testResources/Sniffs/PhpDoc/PropertyDollarSignSniff/InvalidProperties.php
+++ b/testResources/Sniffs/PhpDoc/PropertyDollarSignSniff/InvalidProperties.php
@@ -12,6 +12,8 @@ namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\PhpDoc\PropertyDollarSig
  * @property string[] whoops
  * @property positive-int nice_int
  * @property non-empty-array<\Exception> non_empty_array
+ * @property ABC|EFG union_type
+ * @property ABC&EFG intersection_type
  */
 class InvalidProperties
 {

--- a/tests/Sniffs/PhpDoc/PropertyDollarSignSniffTest.php
+++ b/tests/Sniffs/PhpDoc/PropertyDollarSignSniffTest.php
@@ -29,7 +29,7 @@ it('has errors', function (string $path, array $lines) {
 })->with([
     'invalid properties' => [
         __DIR__ . '/../../../testResources/Sniffs/PhpDoc/PropertyDollarSignSniff/InvalidProperties.php',
-        [6, 7, 8, 9, 10, 11, 12, 13, 14],
+        [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
     ],
 ]);
 


### PR DESCRIPTION
This updates the `PropertyDoc` class to support union and intersection types.