### PR TITLE
Fix: Incompatible signature in GenerateCommand

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -13,7 +13,7 @@ class GenerateCommand extends BaseCommand
         $this->setName("generate-coding-style-stubs");
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln("Worksome's Coding style has 3 stub files (ecs, phpstan and rector)");
 
@@ -44,6 +44,6 @@ class GenerateCommand extends BaseCommand
             ]
         ]);
 
-        return 0;
+        return BaseCommand::SUCCESS;
     }
 }


### PR DESCRIPTION
Symfony/Console in its latest version incorporated many return types, therefore the method signature of the execute method in BaseCommand requires a return type.

If you update the library, the following error is generated because the signature is incompatible.

```
PHP Fatal error:  Declaration of Worksome\CodingStyle\GenerateCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterfa
ce $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\Outpu
tInterface $output)
```
See: https://github.com/symfony/console/blob/2799d9ad8890a3305cecdf6411a2a779769a613c/Command/Command.php#L183

This PR fixes it.
