### PR TITLE
feat: add null union ordering

### DIFF
--- a/src/WorksomeEcsConfig.php
+++ b/src/WorksomeEcsConfig.php
@@ -17,12 +17,14 @@ use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSn
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer;
 use PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer;
+use PhpCsFixer\Fixer\ClassNotation\OrderedTypesFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
 use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer;
 use PhpCsFixer\Fixer\Import\NoUnneededImportAliasFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\NullableTypeDeclarationFixer;
 use PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\OperatorLinebreakFixer;
@@ -135,6 +137,16 @@ class WorksomeEcsConfig
                 '|' => 'no_space',
             ],
         ]);
+
+        $ecsConfig->ruleWithConfiguration(
+            NullableTypeDeclarationFixer::class,
+            ['syntax' => 'union']
+        );
+
+        $ecsConfig->ruleWithConfiguration(
+            OrderedTypesFixer::class,
+            ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none']
+        );
 
         $ecsConfig->rules([
             RequireMultiLineConditionSniff::class,


### PR DESCRIPTION
We decided on this back in 2021, but never added it to our rules list. 👍🏻

I still think that this is the cleanest and most readable formatting.

---

This results in unions like the following:

```diff
// Question-mark null prefix will be converted to union-style
- ?Type
+ Type|null

// `null` will always be the last type in the union
- null|Type
+ Type|null
```