### PR TITLE
feat: update require WithoutTimestamps rule to only account for Laravel models

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This rule will enforce the use of kebab-case for Artisan commands.
 
 **Identifier:** `worksome.laravel.requireWithoutTimestamps`
 
-This rule enforces that all `create`, `update()`, `insert()`, `save()`, `saveQuietly` method calls within Laravel migration files are properly enclosed in a `withoutTimestamps()` context.
+This rule enforces that all `update`, `insert`, `save`, `saveQuietly`, `delete`, `restore`, method calls within Laravel migration files are properly enclosed in a `withoutTimestamps()` context.
 
 ## Custom PHP_CodeSniffer sniffs
 

--- a/src/PHPStan/Laravel/Migrations/RequireWithoutTimestampsRule.php
+++ b/src/PHPStan/Laravel/Migrations/RequireWithoutTimestampsRule.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\FileNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 
 /**

--- a/src/PHPStan/Laravel/Migrations/RequireWithoutTimestampsRule.php
+++ b/src/PHPStan/Laravel/Migrations/RequireWithoutTimestampsRule.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\FileNode;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 
 /**
@@ -16,6 +17,15 @@ use PHPStan\Rules\Rule;
  */
 readonly class RequireWithoutTimestampsRule implements Rule
 {
+    public const TIMESTAMP_MODIFYING_METHODS = [
+        'update',
+        'insert',
+        'save',
+        'saveQuietly',
+        'delete',
+        'restore',
+    ];
+
     public function __construct(private string $migrationsPath = 'database/migrations')
     {
     }
@@ -40,7 +50,7 @@ readonly class RequireWithoutTimestampsRule implements Rule
         }
 
         $traverser = new NodeTraverser();
-        $visitor = new WithoutTimestampsVisitor();
+        $visitor = new WithoutTimestampsVisitor($scope);
         $traverser->addVisitor($visitor);
         $traverser->traverse($node->getNodes());
 

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestClient.php
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestClient.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestClient extends Model {
+
+}

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestClient.php
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestClient.php
@@ -4,6 +4,6 @@ namespace Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTi
 
 use Illuminate\Database\Eloquent\Model;
 
-class TestClient extends Model {
-
+class TestClient extends Model
+{
 }

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestUser.php
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestUser.php
@@ -4,6 +4,6 @@ namespace Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTi
 
 use Illuminate\Database\Eloquent\Model;
 
-class TestUser extends Model {
-
+class TestUser extends Model
+{
 }

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestUser.php
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/Models/TestUser.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestUser extends Model {
+
+}

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/invalid_migration.php.inc
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/invalid_migration.php.inc
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models\TestUser;
 
 return new class extends Migration
 {
@@ -16,8 +17,24 @@ return new class extends Migration
                 ->nullable();
         });
 
-        User::withTrashed()->update([
+        TestUser::withTrashed()->update([
             'test' => 'test',
         ]);
+
+        TestUser::withTrashed()->insert([
+            'test' => 'test',
+        ]);
+
+        $testUser = TestUser::make(['test' => 'test']);
+        $testUser->save();
+
+        $testUser2 = TestUser::make(['test' => 'test']);
+        $testUser2->saveQuietly();
+
+        TestUser::where('test', 'test')
+            ->delete();
+
+        TestUser::where('test', 'test')
+            ->restore();
     }
 };

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/invalid_migration_with_multiple_models.php.inc
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/invalid_migration_with_multiple_models.php.inc
@@ -3,6 +3,8 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models\TestClient;
+use Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models\TestUser;
 
 return new class extends Migration
 {
@@ -16,12 +18,12 @@ return new class extends Migration
                 ->nullable();
         });
 
-        Client::withTrashed()->update([
+        TestClient::withTrashed()->update([
             'test' => 'test',
         ]);
 
-        User::withoutTimestamps(function(){
-            User::withTrashed()->update([
+        TestUser::withoutTimestamps(function(){
+            TestUser::withTrashed()->update([
                 'test' => 'test',
             ]);
         });

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/valid_migration_with_db_update.php.inc
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/valid_migration_with_db_update.php.inc
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models\TestUser;
 
 return new class extends Migration
 {
@@ -17,10 +17,8 @@ return new class extends Migration
                 ->nullable();
         });
 
-        TestUser::withoutTimestamps(function(){
-            TestUser::withTrashed()->update([
-                'test' => 'test',
-            ]);
-        });
+        DB::table('users')->update([
+            'test' => 'test'
+        ]);
     }
 };

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/valid_migration_with_schema_create.php.inc
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/Fixture/database/migrations/valid_migration_with_schema_create.php.inc
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Worksome\CodingStyle\Tests\PHPStan\Laravel\Migrations\RequireWithoutTimestampRule\Fixture\Models\TestUser;
 
 return new class extends Migration
 {
@@ -12,15 +11,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::create('users', function (Blueprint $table) {
             $table->string('test', 50)
                 ->nullable();
-        });
-
-        TestUser::withoutTimestamps(function(){
-            TestUser::withTrashed()->update([
-                'test' => 'test',
-            ]);
         });
     }
 };

--- a/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/RequireWithoutTimestampsRuleTest.php
+++ b/tests/PHPStan/Laravel/Migrations/RequireWithoutTimestampRule/RequireWithoutTimestampsRuleTest.php
@@ -13,18 +13,47 @@ it('checks withoutTimestamps in migration rule', function (string $path, array .
     'valid migration' => [
         __DIR__ . '/Fixture/database/migrations/valid_migration.php.inc',
     ],
+    'valid migration with Schema::create' => [
+        __DIR__ . '/Fixture/database/migrations/valid_migration_with_schema_create.php.inc',
+    ],
+    'valid migration with DB::update' => [
+        __DIR__ . '/Fixture/database/migrations/valid_migration_with_db_update.php.inc',
+    ],
+    'valid migration with delete method' => [
+        __DIR__ . '/Fixture/database/migrations/valid_migration_with_db_update.php.inc',
+    ],
     'invalid migration' => [
         __DIR__ . '/Fixture/database/migrations/invalid_migration.php.inc',
         [
-            "Line 19: The 'update()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
-            19,
+            "Line 20: The 'update()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            20,
+        ],
+        [
+            "Line 24: The 'insert()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            24,
+        ],
+        [
+            "Line 29: The 'save()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            29,
+        ],
+        [
+            "Line 32: The 'saveQuietly()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            32,
+        ],
+        [
+            "Line 34: The 'delete()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            34,
+        ],
+        [
+            "Line 37: The 'restore()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            37,
         ],
     ],
     'invalid migration with multiple models' => [
-        __DIR__ . '/Fixture/database/migrations/invalid_migration.php.inc',
+        __DIR__ . '/Fixture/database/migrations/invalid_migration_with_multiple_models.php.inc',
         [
-            "Line 19: The 'update()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
-            19,
+            "Line 21: The 'update()' method call should be within 'withoutTimestamps()' context to prevent unintended timestamp updates.",
+            21,
         ],
     ],
 ]);


### PR DESCRIPTION
In this PR I've updated rule to scope it only to Laravel models. As Scheme::create() or DB::update() should not be included in this check.