### PR TITLE
feat: JIRA-13993 Refactor to conditional tags

### DIFF
--- a/larastan.neon
+++ b/larastan.neon
@@ -3,6 +3,10 @@ includes:
     - ../../larastan/larastan/extension.neon
 
 parameters:
+    worksomeLaravel:
+        disallowEnvironmentChecks: true
+        enforceKebabCaseArtisanCommands: true
+        requireWithoutTimestamps: true
     namespaceAndSuffix:
         App\Events: Event
         App\Listener: Listener
@@ -20,12 +24,20 @@ parameters:
             identifier: missingType.iterableValue
             reportUnmatched: false
 
-rules:
-    - Worksome\CodingStyle\PHPStan\Laravel\EnforceKebabCaseArtisanCommandsRule
-    - Worksome\CodingStyle\PHPStan\Laravel\DisallowEnvironmentCheck\DisallowEnvironmentCheckRule
-    - Worksome\CodingStyle\PHPStan\Laravel\Migrations\RequireWithoutTimestampsRule
+parametersSchema:
+    worksomeLaravel: structure([
+        disallowEnvironmentChecks: bool()
+        enforceKebabCaseArtisanCommands: bool()
+        requireWithoutTimestamps: bool()
+    ])
 
 services:
+    -
+        class: Worksome\CodingStyle\PHPStan\Laravel\DisallowEnvironmentCheck\DisallowEnvironmentCheckRule
+    -
+        class: Worksome\CodingStyle\PHPStan\Laravel\EnforceKebabCaseArtisanCommandsRule
+    -
+        class: Worksome\CodingStyle\PHPStan\Laravel\Migrations\RequireWithoutTimestampsRule
     -
         class: Vural\LarastanStrictRules\Rules\NoDynamicWhereRule
         tags:
@@ -87,7 +99,10 @@ services:
         tags:
             - phpstan.rules.rule
 
-#    -
-#        class: Vural\LarastanStrictRules\Rules\NoLocalQueryScopeRule
-#        tags:
-#            - phpstan.rules.rule
+conditionalTags:
+    Worksome\CodingStyle\PHPStan\Laravel\DisallowEnvironmentCheck\DisallowEnvironmentCheckRule:
+        phpstan.rules.rule: %worksomeLaravel.disallowEnvironmentChecks%
+    Worksome\CodingStyle\PHPStan\Laravel\EnforceKebabCaseArtisanCommandsRule:
+        phpstan.rules.rule: %worksomeLaravel.enforceKebabCaseArtisanCommands%
+    Worksome\CodingStyle\PHPStan\Laravel\Migrations\RequireWithoutTimestampsRule:
+        phpstan.rules.rule: %worksomeLaravel.requireWithoutTimestamps%

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,24 +3,37 @@ includes:
     - ../../spaze/phpstan-disallowed-calls/extension.neon
 
 parameters:
-    namespaceAndSuffix: []
     disallowedMethodCalls:
         - method: 'Pest\PendingObjects\TestCall::only()'
           message: 'calls to Pest''s "only()" method should not be pushed to development.'
+    namespaceAndSuffix: []
+    worksome:
+        declareStrictTypes: true
+        disallowPhpunit: true
+        namespaceBasedSuffix: true
 
 parametersSchema:
     namespaceAndSuffix: arrayOf(string(), string())
+    worksome: structure([
+        declareStrictTypes: bool()
+        disallowPhpunit: bool()
+        namespaceBasedSuffix: bool()
+    ])
 
-rules:
-    - Worksome\CodingStyle\PHPStan\DisallowPHPUnitRule
 services:
     -
+        class: Worksome\CodingStyle\PHPStan\DisallowPHPUnitRule
+    -
         class: Worksome\CodingStyle\PHPStan\DeclareStrictTypesRule
-        tags:
-            - phpstan.rules.rule
     -
         class: Worksome\CodingStyle\PHPStan\NamespaceBasedSuffixRule
         arguments:
             namespaceAndSuffix: %namespaceAndSuffix%
-        tags:
-            - phpstan.rules.rule
+
+conditionalTags:
+    Worksome\CodingStyle\PHPStan\DeclareStrictTypesRule:
+        phpstan.rules.rule: %worksome.declareStrictTypes%
+    Worksome\CodingStyle\PHPStan\DisallowPHPUnitRule:
+        phpstan.rules.rule: %worksome.disallowPhpunit%
+    Worksome\CodingStyle\PHPStan\NamespaceBasedSuffixRule:
+        phpstan.rules.rule: %worksome.namespaceBasedSuffix%


### PR DESCRIPTION
This updates to use conditional tags for PHPStan. All rules are defaulted to be run, but can be switched off by setting a parameter (e.g. `worksomeLaravel.disallowEnvironmentChecks`) rather than having to include all rules manually on a custom config.

Tested on a few repositories, and seems to be working nicely!