### PR TITLE
feat: remove JetBrains attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "php": "^8.2",
         "composer-plugin-api": "^2.0",
         "canvural/larastan-strict-rules": "^2.1.10",
-        "jetbrains/phpstorm-attributes": "^1.2",
         "larastan/larastan": "^2.9.11",
         "phpstan/phpstan": "^1.12.11",
         "phpstan/phpstan-mockery": "^1.1.3",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ includes:
     - ../../spaze/phpstan-disallowed-calls/extension.neon
 
 parameters:
+    disallowedNamespaces:
+        - namespace: 'JetBrains\PhpStorm\*'
+          message: 'use native PHPDoc comments instead.'
     disallowedMethodCalls:
         - method: 'Pest\PendingObjects\TestCall::only()'
           message: 'calls to Pest''s "only()" method should not be pushed to development.'

--- a/src/Rector/config/sets/generic-code-quality.php
+++ b/src/Rector/config/sets/generic-code-quality.php
@@ -8,6 +8,6 @@ use Worksome\CodingStyle\Rector\Generic\DisallowedAttributesRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
         ->ruleWithConfiguration(DisallowedAttributesRector::class, [
-            JetBrains\PhpStorm\Pure::class,
+            'JetBrains\PhpStorm\Pure',
         ]);
 };

--- a/tests/Rector/DisallowedAttributesRector/config/configured_rule.php
+++ b/tests/Rector/DisallowedAttributesRector/config/configured_rule.php
@@ -8,6 +8,6 @@ use Worksome\CodingStyle\Rector\Generic\DisallowedAttributesRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
         ->ruleWithConfiguration(DisallowedAttributesRector::class, [
-            JetBrains\PhpStorm\Pure::class,
+            'JetBrains\PhpStorm\Pure',
         ]);
 };


### PR DESCRIPTION
Related to JIRA-13996 and JIRA-13997

PhpStorm supports `@deprecated`, `@var array{}`, and `@var object{}` PHPDoc comments, so these are no longer recommended. PHPStan also doesn't support them, so this would add more visibility into our code.

I've kept the auto-removal of `Pure` with Rector, but we don't want to auto-remove `Deprecated` and `ArrayShape` as they hold data that we should use for replacing them.