### PR TITLE
feat: remove deprecated interface usage

### DIFF
--- a/src/Rector/WorksomeSetList.php
+++ b/src/Rector/WorksomeSetList.php
@@ -2,9 +2,7 @@
 
 namespace Worksome\CodingStyle\Rector;
 
-use Rector\Set\Contract\SetListInterface;
-
-class WorksomeSetList implements SetListInterface
+class WorksomeSetList
 {
     public const LARAVEL_CODE_QUALITY = __DIR__ . '/config/sets/laravel-code-quality.php';
 


### PR DESCRIPTION
It looks like we don't actually need the `SetListInterface` here, as we are importing the config files manually.

Closes #88