### PR TITLE
feat: JIRA-14531 Cleanup Larastan Strict Rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,22 +6,22 @@
         "php": "^8.2",
         "composer-plugin-api": "^2.0",
         "canvural/larastan-strict-rules": "^3.0",
-        "larastan/larastan": "^3.0",
-        "phpstan/phpstan": "^2.0",
+        "larastan/larastan": "^3.1",
+        "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-mockery": "^2.0",
         "rector/rector": "^2.0",
-        "slevomat/coding-standard": "^8.15",
-        "spaze/phpstan-disallowed-calls": "^4.0.1",
-        "symplify/easy-coding-standard": "^12.4"
+        "slevomat/coding-standard": "^8.16",
+        "spaze/phpstan-disallowed-calls": "^4.4",
+        "symplify/easy-coding-standard": "^12.5"
     },
     "require-dev": {
-        "composer/composer": "^2.7",
-        "friendsofphp/php-cs-fixer": "^3.53",
-        "orchestra/testbench": "^9.5",
-        "pestphp/pest": "^3.0",
+        "composer/composer": "^2.8",
+        "friendsofphp/php-cs-fixer": "^3.70",
+        "orchestra/testbench": "^9.11",
+        "pestphp/pest": "^3.7",
         "spatie/invade": "^1.1.1",
-        "squizlabs/php_codesniffer": "^3.8"
+        "squizlabs/php_codesniffer": "^3.11"
     },
     "autoload": {
         "psr-4": {

--- a/larastan.neon
+++ b/larastan.neon
@@ -1,8 +1,51 @@
 includes:
     - ./phpstan.neon
     - ../../larastan/larastan/extension.neon
+    - ../../canvural/larastan-strict-rules/rules.neon
 
 parameters:
+    larastanStrictRules:
+        allRules: false
+        noFacade: true
+        noValidationInController: true
+        scopeShouldReturnQueryBuilder: true
+        noPropertyAccessor: true
+        noGlobalLaravelFunction: true
+    allowedGlobalFunctions:
+        - class_basename
+        - class_uses_recursive
+        - e
+        - env
+        - object_get
+        - preg_replace_array
+        - retry
+        - str
+        - tap
+        - throw_if
+        - throw_unless
+        - trait_uses_recursive
+        - with
+        - collect
+        - data_fill
+        - data_get
+        - data_set
+        - value
+        - config
+        - fake
+        - method_field
+        - now
+        - old
+        - redirect
+        - response
+        - route
+        - trans
+        - trans_choice
+        - __
+        - view
+        - url
+        - secure_url
+        - asset
+        - secure_asset
     worksomeLaravel:
         allRules: true
         disallowEnvironmentChecks: %worksomeLaravel.allRules%
@@ -40,66 +83,6 @@ services:
         class: Worksome\CodingStyle\PHPStan\Laravel\EnforceKebabCaseArtisanCommandsRule
     -
         class: Worksome\CodingStyle\PHPStan\Laravel\Migrations\RequireWithoutTimestampsRule
-    -
-        class: Vural\LarastanStrictRules\Rules\NoDynamicWhereRule
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Vural\LarastanStrictRules\Rules\NoFacadeRule
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Vural\LarastanStrictRules\Rules\NoValidationInControllerRule
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Vural\LarastanStrictRules\Rules\ScopeShouldReturnQueryBuilderRule
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Vural\LarastanStrictRules\Rules\NoPropertyAccessorRule
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Vural\LarastanStrictRules\Rules\NoGlobalLaravelFunctionRule
-        arguments:
-            allowedFunctions:
-                - class_basename
-                - class_uses_recursive
-                - e
-                - env
-                - object_get
-                - preg_replace_array
-                - retry
-                - str
-                - tap
-                - throw_if
-                - throw_unless
-                - trait_uses_recursive
-                - with
-                - collect
-                - data_fill
-                - data_get
-                - data_set
-                - value
-                - config
-                - fake
-                - method_field
-                - now
-                - old
-                - redirect
-                - response
-                - route
-                - trans
-                - trans_choice
-                - __
-                - view
-                - url
-                - secure_url
-                - asset
-                - secure_asset
-        tags:
-            - phpstan.rules.rule
 
 conditionalTags:
     Worksome\CodingStyle\PHPStan\Laravel\DisallowEnvironmentCheck\DisallowEnvironmentCheckRule:


### PR DESCRIPTION
This cleans up the usage of Larastan strict rules using parameters, and removes the `noDynamicWhere` rule.