### PR TITLE
feat!: JIRA-17366 Update to ECS 13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This repository contains the coding style followed by Worksome.
 
-It includes configuration for [ECS](https://github.com/symplify/easy-coding-standard), [PHPStan](https://phpstan.org), and [Rector](https://getrector.org).
+It includes configuration for [ECS](https://github.com/ecsphp/ecs), [PHPStan](https://phpstan.org), and [Rector](https://getrector.org).
 
 ## Setup
 
@@ -51,10 +51,6 @@ $ composer rector:fix
 
 The Worksome code style extends the [PSR-12 base rule set](https://php-fig.org/psr/psr-12).
 
-### Excluded / Skipped Rules
-
-- [`UnaryOperatorSpacesFixer`](https://cs.symfony.com/doc/rules/operator/unary_operator_spaces.html)
-
 ### Additional / Customised Rules
 
 > **Note:** Customised rules have a ⚙️ icon.
@@ -85,6 +81,7 @@ The Worksome code style extends the [PSR-12 base rule set](https://php-fig.org/p
 - [`NoUnusedImportsFixer`](https://cs.symfony.com/doc/rules/import/no_unused_imports.html)
 - [`TrailingCommaInMultilineFixer`](https://cs.symfony.com/doc/rules/control_structure/trailing_comma_in_multiline.html)
 - [`TypesSpacesFixer`](https://cs.symfony.com/doc/rules/whitespace/types_spaces.html)
+- [`UnaryOperatorSpacesFixer`](https://cs.symfony.com/doc/rules/operator/unary_operator_spaces.html)
 
 #### [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 

--- a/composer.json
+++ b/composer.json
@@ -6,20 +6,20 @@
         "php": "^8.4",
         "composer-plugin-api": "^2.0",
         "canvural/larastan-strict-rules": "^3.0",
-        "larastan/larastan": "^3.9",
-        "phpstan/phpstan": "^2.1",
+        "larastan/larastan": "^3.10",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-mockery": "^2.0",
-        "rector/rector": "^2.3",
-        "slevomat/coding-standard": "^8.27.1",
+        "rector/rector": "^2.4",
+        "slevomat/coding-standard": "^8.29",
         "spaze/phpstan-disallowed-calls": "^4.8",
-        "symplify/easy-coding-standard": "^13.0"
+        "symplify/easy-coding-standard": "^13.2.1"
     },
     "require-dev": {
-        "composer/composer": "^2.9",
-        "friendsofphp/php-cs-fixer": "^3.94",
-        "orchestra/testbench": "^9.16",
-        "pestphp/pest": "^4.4",
+        "composer/composer": "^2.10",
+        "friendsofphp/php-cs-fixer": "^3.95.5",
+        "orchestra/testbench": "^10.11",
+        "pestphp/pest": "^4.7",
         "spatie/invade": "^1.1.1",
         "squizlabs/php_codesniffer": "^4.0.1"
     },
@@ -44,7 +44,7 @@
         },
         {
             "name": "Owen Voke",
-            "email": "owen.voke@worksome.com"
+            "email": "owen@worksome.com"
         },
         {
             "name": "Odinn Adalsteinsson",

--- a/ecs.php
+++ b/ecs.php
@@ -2,15 +2,10 @@
 
 declare(strict_types=1);
 
-use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Worksome\CodingStyle\WorksomeEcsConfig;
 
-
-return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->paths([
+return WorksomeEcsConfig::configure()
+    ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ]);
-
-    WorksomeEcsConfig::setup($ecsConfig);
-};

--- a/src/WorksomeEcsConfig.php
+++ b/src/WorksomeEcsConfig.php
@@ -64,7 +64,7 @@ use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\UselessConstantTypeHintSniff;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
-use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+use Symplify\EasyCodingStandard\Configuration\ECSConfigBuilder;
 use Worksome\CodingStyle\PhpCsFixer\SpaceInGenericsFixer;
 use Worksome\CodingStyle\Sniffs\Classes\ExceptionSuffixSniff;
 use Worksome\CodingStyle\Sniffs\Comments\DisallowTodoCommentsSniff;
@@ -80,147 +80,132 @@ use Worksome\CodingStyle\Sniffs\PhpDoc\PropertyDollarSignSniff;
 
 class WorksomeEcsConfig
 {
-    public static function setup(ECSConfig $ecsConfig): void
+    public static function configure(): ECSConfigBuilder
     {
-        $ecsConfig->sets([
-            SetList::PSR_12,
-        ]);
-
-        $ecsConfig->skip(self::skips());
-
-        $ecsConfig->ruleWithConfiguration(RequireMultiLineTernaryOperatorSniff::class, [
-            'lineLengthLimit' => 120,
-        ]);
-        $ecsConfig->ruleWithConfiguration(CommentedOutCodeSniff::class, [
-            'maxPercentage' => 70,
-        ]);
-        $ecsConfig->ruleWithConfiguration(PhpdocAlignFixer::class, [
-            'align' => PhpdocAlignFixer::ALIGN_VERTICAL,
-        ]);
-
-        $ecsConfig->ruleWithConfiguration(OrderedImportsFixer::class, [
-            'imports_order' => [
-                OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
-                OrderedImportsFixer::IMPORT_TYPE_CONST,
-            ],
-            'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
-        ]);
-        $ecsConfig->ruleWithConfiguration(OperatorLinebreakFixer::class, [
-            'only_booleans' => true,
-        ]);
-        $ecsConfig->ruleWithConfiguration(ForbiddenFunctionsSniff::class, [
-            'forbiddenFunctions' => [
-                'dd' => null,
-                'dump' => null,
-                'var_dump' => null,
-                'ddd' => null,
-                'ray' => null,
-            ],
-        ]);
-        $ecsConfig->ruleWithConfiguration(EmptyLinesAroundClassBracesSniff::class, [
-            'linesCountAfterOpeningBrace' => 0,
-            'linesCountBeforeClosingBrace' => 0,
-        ]);
-        $ecsConfig->ruleWithConfiguration(ForbiddenAnnotationsSniff::class, [
-            'forbiddenAnnotations' => [
-                '@package',
-                '@author',
-                '@created',
-                '@version',
-                '@copyright',
-                '@license',
-                '@inheritDoc',
-            ],
-        ]);
-        $ecsConfig->ruleWithConfiguration(LineLengthFixer::class, [
-            LineLengthFixer::INLINE_SHORT_LINES => false,
-        ]);
-
-        $ecsConfig->ruleWithConfiguration(BinaryOperatorSpacesFixer::class, [
-            'operators' => [
-                '=>' => null,
-                '|' => 'no_space',
-            ],
-        ]);
-
-        $ecsConfig->ruleWithConfiguration(
-            NullableTypeDeclarationFixer::class,
-            ['syntax' => 'union']
-        );
-
-        $ecsConfig->ruleWithConfiguration(
-            OrderedTypesFixer::class,
-            ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none']
-        );
-
-        $ecsConfig->rules([
-            RequireMultiLineConditionSniff::class,
-            RequireShortTernaryOperatorSniff::class,
-            ReturnTypeHintSpacingSniff::class,
-            RequireMultiLineCallSniff::class,
-            SpaceAfterNotSniff::class,
-            RequireMultiLineMethodSignatureSniff::class,
-            RequireTrailingCommaInDeclarationSniff::class,
-            SpaceInGenericsFixer::class,
-            PhpdocSeparationFixer::class,
-            RequireOneNamespaceInFileSniff::class,
-            ArraySyntaxFixer::class,
-            ListSyntaxFixer::class,
-            NoEmptyCommentFixer::class,
-            NoEmptyPhpdocFixer::class,
-            EndFileNewlineSniff::class,
-            NamespaceDeclarationSniff::class,
-            MethodDeclarationSniff::class,
-            LineEndingFixer::class,
-            SingleTraitInsertPerStatementFixer::class,
-            ShortScalarCastFixer::class,
-            UselessConstantTypeHintSniff::class,
-            NoUnneededImportAliasFixer::class,
-            NoEmptyStatementFixer::class,
-            ModernClassNameReferenceSniff::class,
-            ClassConstantVisibilitySniff::class,
-            PropertyDeclarationSniff::class,
-            ParameterTypeHintSpacingSniff::class,
-            DisallowGroupUseSniff::class,
-            UselessInheritDocCommentSniff::class,
-            SpaceAfterCastSniff::class,
-            ClassDefinitionFixer::class,
-            LowercaseDeclarationSniff::class,
-            InlineControlStructureSniff::class,
-            LowerCaseKeywordSniff::class,
-            LanguageConstructSpacingSniff::class,
-            MethodSpacingSniff::class,
-            PropertySpacingSniff::class,
-            ClassMemberSpacingSniff::class,
-            NoUnusedImportsFixer::class,
-            ExceptionSuffixSniff::class,
-            DisallowTodoCommentsSniff::class,
-            DisallowCompactUsageSniff::class,
-            ConfigFilenameKebabCaseSniff::class,
-            DisallowBladeOutsideOfResourcesDirectorySniff::class,
-            DisallowEnvUsageSniff::class,
-            DisallowHasFactorySniff::class,
-            EventListenerSuffixSniff::class,
-            DisallowParamNoTypeOrCommentSniff::class,
-            PropertyDollarSignSniff::class,
-            TypesSpacesFixer::class,
-            PascalCasingEnumCasesSniff::class,
-            SingleQuoteFixer::class,
-            BlankLineBeforeStatementFixer::class,
-            TrailingCommaInMultilineFixer::class,
-            ClassAttributesSeparationFixer::class,
-            PhpdocNoUselessInheritdocFixer::class,
-            PhpdocTrimFixer::class,
-            StandardizeNotEqualsFixer::class,
-        ]);
-    }
-
-    public static function skips(array $additional = []): array
-    {
-        return [
-            UnaryOperatorSpacesFixer::class,
-            ...$additional,
-        ];
+        return ECSConfig::configure()
+            ->withPreparedSets(psr12: true)
+            ->withConfiguredRule(RequireMultiLineTernaryOperatorSniff::class, [
+                'lineLengthLimit' => 120,
+            ])
+            ->withConfiguredRule(CommentedOutCodeSniff::class, [
+                'maxPercentage' => 70,
+            ])
+            ->withConfiguredRule(PhpdocAlignFixer::class, [
+                'align' => PhpdocAlignFixer::ALIGN_VERTICAL,
+            ])
+            ->withConfiguredRule(OrderedImportsFixer::class, [
+                'imports_order' => [
+                    OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                    OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                    OrderedImportsFixer::IMPORT_TYPE_CONST,
+                ],
+                'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
+            ])
+            ->withConfiguredRule(OperatorLinebreakFixer::class, [
+                'only_booleans' => true,
+            ])
+            ->withConfiguredRule(ForbiddenFunctionsSniff::class, [
+                'forbiddenFunctions' => [
+                    'dd' => null,
+                    'dump' => null,
+                    'var_dump' => null,
+                    'ddd' => null,
+                    'ray' => null,
+                ],
+            ])
+            ->withConfiguredRule(EmptyLinesAroundClassBracesSniff::class, [
+                'linesCountAfterOpeningBrace' => 0,
+                'linesCountBeforeClosingBrace' => 0,
+            ])
+            ->withConfiguredRule(ForbiddenAnnotationsSniff::class, [
+                'forbiddenAnnotations' => [
+                    '@package',
+                    '@author',
+                    '@created',
+                    '@version',
+                    '@copyright',
+                    '@license',
+                    '@inheritDoc',
+                ],
+            ])
+            ->withConfiguredRule(LineLengthFixer::class, [
+                LineLengthFixer::INLINE_SHORT_LINES => false,
+            ])
+            ->withConfiguredRule(BinaryOperatorSpacesFixer::class, [
+                'operators' => [
+                    '=>' => null,
+                    '|' => 'no_space',
+                ],
+            ])
+            ->withConfiguredRule(NullableTypeDeclarationFixer::class, [
+                'syntax' => 'union',
+            ])
+            ->withConfiguredRule(OrderedTypesFixer::class, [
+                'null_adjustment' => 'always_last',
+                'sort_algorithm' => 'none',
+            ])
+            ->withConfiguredRule(UnaryOperatorSpacesFixer::class, [
+                'only_dec_inc' => true,
+            ])
+            ->withRules([
+                RequireMultiLineConditionSniff::class,
+                RequireShortTernaryOperatorSniff::class,
+                ReturnTypeHintSpacingSniff::class,
+                RequireMultiLineCallSniff::class,
+                SpaceAfterNotSniff::class,
+                RequireMultiLineMethodSignatureSniff::class,
+                RequireTrailingCommaInDeclarationSniff::class,
+                SpaceInGenericsFixer::class,
+                PhpdocSeparationFixer::class,
+                RequireOneNamespaceInFileSniff::class,
+                ArraySyntaxFixer::class,
+                ListSyntaxFixer::class,
+                NoEmptyCommentFixer::class,
+                NoEmptyPhpdocFixer::class,
+                EndFileNewlineSniff::class,
+                NamespaceDeclarationSniff::class,
+                MethodDeclarationSniff::class,
+                LineEndingFixer::class,
+                SingleTraitInsertPerStatementFixer::class,
+                ShortScalarCastFixer::class,
+                UselessConstantTypeHintSniff::class,
+                NoUnneededImportAliasFixer::class,
+                NoEmptyStatementFixer::class,
+                ModernClassNameReferenceSniff::class,
+                ClassConstantVisibilitySniff::class,
+                PropertyDeclarationSniff::class,
+                ParameterTypeHintSpacingSniff::class,
+                DisallowGroupUseSniff::class,
+                UselessInheritDocCommentSniff::class,
+                SpaceAfterCastSniff::class,
+                ClassDefinitionFixer::class,
+                LowercaseDeclarationSniff::class,
+                InlineControlStructureSniff::class,
+                LowerCaseKeywordSniff::class,
+                LanguageConstructSpacingSniff::class,
+                MethodSpacingSniff::class,
+                PropertySpacingSniff::class,
+                ClassMemberSpacingSniff::class,
+                NoUnusedImportsFixer::class,
+                ExceptionSuffixSniff::class,
+                DisallowTodoCommentsSniff::class,
+                DisallowCompactUsageSniff::class,
+                ConfigFilenameKebabCaseSniff::class,
+                DisallowBladeOutsideOfResourcesDirectorySniff::class,
+                DisallowEnvUsageSniff::class,
+                DisallowHasFactorySniff::class,
+                EventListenerSuffixSniff::class,
+                DisallowParamNoTypeOrCommentSniff::class,
+                PropertyDollarSignSniff::class,
+                TypesSpacesFixer::class,
+                PascalCasingEnumCasesSniff::class,
+                SingleQuoteFixer::class,
+                BlankLineBeforeStatementFixer::class,
+                TrailingCommaInMultilineFixer::class,
+                ClassAttributesSeparationFixer::class,
+                PhpdocNoUselessInheritdocFixer::class,
+                PhpdocTrimFixer::class,
+                StandardizeNotEqualsFixer::class,
+            ]);
     }
 }

--- a/stubs/ecs.php.stub
+++ b/stubs/ecs.php.stub
@@ -2,16 +2,11 @@
 
 declare(strict_types=1);
 
-use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Worksome\CodingStyle\WorksomeEcsConfig;
 
-
-return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->paths([
+return WorksomeEcsConfig::configure()
+    ->withPaths([
         __DIR__ . '/app',
         __DIR__ . '/tests',
         __DIR__ . '/config',
     ]);
-
-    WorksomeEcsConfig::setup($ecsConfig);
-};


### PR DESCRIPTION
This updates from ECS 13.1 to ECS 13.2 and refactors the config.

> [!Warning]
> Due to the changes to the config, and the `unary_operator_spaces` rule no longer being skipped by default, this is a breaking change and should be released as a major version bump.